### PR TITLE
Fix CI/CD badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![build](https://github.com/JKatzwinkel/tla-web/workflows/build/badge.svg)
-![deploy](https://github.com/JKatzwinkel/tla-web/workflows/deploy/badge.svg)
+![build](https://github.com/thesaurus-linguae-aegyptiae/tla-web/workflows/build/badge.svg)
+![deploy](https://github.com/thesaurus-linguae-aegyptiae/tla-web/workflows/deploy/badge.svg)
 ![LINE](https://img.shields.io/badge/line--coverage-91.71%25-brightgreen.svg)
 ![METHOD](https://img.shields.io/badge/method--coverage-85.64%25-brightgreen.svg)
 


### PR DESCRIPTION
CI/CD badges in README still point to fork instead of upstream pipeline statuses. This change fixes that by making the badges in the README header line display the correct statuses.