### PR TITLE
Nutzung von URL Parameter ohne JavaScript-Umweg

### DIFF
--- a/src/main/resources/templates/fragments/common.html
+++ b/src/main/resources/templates/fragments/common.html
@@ -285,37 +285,19 @@
 
     <!-- sentence hieroglyphs -->
     <div th:fragment="sentence-hieroglyphs" th:if="*{hasGlyphs}" class="result-list-item-element hieroglyphs">
-      <a th:each="token : *{tokens}" th:href="${(#mvc.url('LC#getSingleObjectDetailsPage').arg(0,token.lemma.id)).build()}" th:id="|hieroglyphs-${token.id}|">
+      <a th:each="token : *{tokens}" th:href="${(#mvc.url('LC#getSingleObjectDetailsPage').arg(0,token.lemma.id)).build()}" th:id="|hieroglyphs-${token.id}|" th:class="${(#request.getParameter('tokens[0].lemma.id') == token.lemma.id) ? 'highlight' : '' }">
         <div th:replace=" :: token-hieroglyphs"/>
-            <script th:inline="javascript">
-				  //<![CDATA[
-					{
-					  if(lemmaID == /*[[${token.lemma.id}]]*/) {
-						  document.getElementById('hieroglyphs-' + /*[[${token.id}]]*/).classList.add('highlight'); 
-					  }	  
-				  }
-				  //]]>
-				  </script>
       </a>
     </div>
 
     <!-- sentence transcription -->
     <div th:fragment="sentence-transcription" class="result-list-item-element transcription">
       <p class="bbaw-libertine mb-2">
-        <span th:each="token : *{tokens}" th:id="|transliteration-${token.id}|">
+        <span th:each="token : *{tokens}" th:id="|transliteration-${token.id}|" th:class="${(#request.getParameter('tokens[0].lemma.id') == token.lemma.id) ? 'highlight' : '' }">
 		  <a  th:if="${token.lemma.id}" th:href="${(#mvc.url('LC#getSingleObjectDetailsPage').arg(0,token.lemma.id)).build()}"
              th:text="${token.label}"
              th:class="|sentence-token token-${token.type}|"
              th:classappend="${token.rubrum} ? rubrum" />
-            <script th:inline="javascript">
-				  //<![CDATA[
-					{
-					  if(lemmaID == /*[[${token.lemma.id}]]*/) {
-						  document.getElementById('transliteration-' + /*[[${token.id}]]*/).classList.add('highlight'); 
-					  }	  
-				  }
-				  //]]>
-				  </script>
 			 <span th:unless="${token.lemma.id}" th:text="${token.label}" th:class="|sentence-token token-${token.type}|"/>
 		</span>
       </p>

--- a/src/main/resources/templates/fragments/search/results.html
+++ b/src/main/resources/templates/fragments/search/results.html
@@ -86,8 +86,8 @@
         <div class="mt-3 pt-1 pb-1">
           <div class="container-annotation-switch">
             <div class="container-annotation">
-				         <div th:each="token : *{tokens}">
-					         <ul  th:id="|block-${token.id}|" class="annotation-block">
+				         <div th:each="token : *{tokens}"  th:id="|block-${token.id}|">
+					         <ul class="annotation-block"  th:classappend="${(#request.getParameter('tokens[0].lemma.id') == token.lemma.id) ? 'highlight' : '' }">
 							      <a th:if="${token.lemma.id}" th:href="'/lemma/'+${token.lemma.id}" target="_blank"><div class="occ-list-item-element hieroglyphs">
 								  		<li th:replace="fragments/common :: token-hieroglyphs"/>
 								  		<hr class="blockline"> 
@@ -125,15 +125,6 @@
 								  		<hr class="blockline bid">  
 								  </div>						      
 						    </ul>
-								<script th:inline="javascript">
-								  //<![CDATA[
-									{
-									  if(lemmaID == /*[[${token.lemma.id}]]*/) {
-										  document.getElementById('block-' + /*[[${token.id}]]*/).classList.add('highlight'); 
-									  }	  
-								  }
-								  //]]>
-								  </script>
 			         	</div>
 		            </div>
 	            </div>

--- a/src/main/resources/templates/sentence/search.html
+++ b/src/main/resources/templates/sentence/search.html
@@ -9,29 +9,15 @@
 
   <body>
 
-    <div layout:fragment="content">
+    <div th:if="${#request.getParameter('tokens[0].lemma.id')}" layout:fragment="content">
 
       <!-- result page heading -->
       <div class="search-header row mb-3">
          <div class="col-sm-12 col-md-6 rcol-lg-6 result">
             <h2 class="id mt-1" th:text="#{result_page_title_sentence}">Sentence Search Results</h2> 
             <div class="ml-3 flex"><strong th:text="#{result_page_description_query}">Search parameter</strong>: 
-            <span id="queryLemmaIDHeader" > </span>
-            <span id="queryLemmaID"> </span>
-            <script th:inline="javascript">
-				  //<![CDATA[
-				  {
-					  const queryString = window.location.search;
-					  const urlParams = new URLSearchParams(queryString);
-					  
-					  var lemmaID=urlParams.get('tokens[0].lemma.id'); // wieso ist der Name so komplex? Mehrwortsuche?
-					  if(lemmaID !="") {
-						  document.getElementById("queryLemmaIDHeader").innerHTML ="Lemma ID = "; // wie kann man hier #{field_label_lemma_id} einfügen
-						  document.getElementById("queryLemmaID").innerHTML =lemmaID;
-					  }	  
-				  }
-				  //]]>
-				  </script>
+					<span id="queryLemmaIDHeader" th:text="#{field_label_lemma_id}"> </span> = 
+					<span id="queryLemmaID" th:text="${#request.getParameter('tokens[0].lemma.id')}"> </span>
              </div>
          </div>
         <div th:replace="fragments/common :: social('sentence-search-results')"/>
@@ -82,5 +68,22 @@
       </div>
 
     </div>
+
+    <!-- no valid lemma search paramenter name -->
+    <div th:unless="${#request.getParameter('tokens[0].lemma.id')}" layout:fragment="content">
+      <div class="row">
+        <div class="col-lg-8 content">
+             <strong>404: No valid search parameter submitted.</strong>
+        </div>
+
+        <!-- sidebar -->
+        <div class="col-lg-4 sidebar">
+          <div class="sticky-top m-4">
+            <div th:replace="fragments/search/results :: modify-search-button(${modifySearchUrl})"/>
+          </div>
+        </div>
+      </div>
+    </div>
+	
   </body>
 </html>


### PR DESCRIPTION
Muster:
th:text="${param.root_enc}"
Wenn Parameter kein gültiger Varaiblenstring, komplexer:
th:text="${#request.getParameter('tokens[0].lemma.id')}"