### PR TITLE
Correct: Labels not linked to radio checkboxes on the search page

### DIFF
--- a/src/main/resources/templates/fragments/search/forms.html
+++ b/src/main/resources/templates/fragments/search/forms.html
@@ -405,7 +405,7 @@
                  <div th:each="enc : ${encodings}" class="form-check form-check-inline">
 						 
 							  <input class="form-check-input transcription-enc-btn"  type="radio" name="transcription_enc" th:id="|transcription_enc_${enc}|" th:field="*{transcription.enc}" th:value="${enc}"/>
-							  <label class="form-check-label" for="|transcription_enc_${enc}|"   th:text="#{|field_value_label_enc_${enc}|}">Unicode</label>
+							  <label class="form-check-label" th:for="|transcription_enc_${enc}|"   th:text="#{|field_value_label_enc_${enc}|}">Unicode</label>
 							 
 						</div>
 					


### PR DESCRIPTION
Because of the typo ("for" used instead of "th:for") in forms.html

Not tested