### PR TITLE
Fehlerhafte Sentence-ID lookup repariert;

### DIFF
--- a/src/main/java/tla/web/mvc/SentenceController.java
+++ b/src/main/java/tla/web/mvc/SentenceController.java
@@ -81,9 +81,9 @@ public class SentenceController extends HierarchicObjectController<Sentence, Sen
     	 model.addAttribute("contextInformation", searchConfig.getContextInformation());
         return super.getSearchResultsPage(form, page, params, model);
     }
-  
+    
 	@RequestMapping(value = "/token/lookup", method = RequestMethod.GET)
-	public RedirectView lookup(@RequestParam String id) {
+	public RedirectView lookupToken(@RequestParam String id) {
 		return new RedirectView(String.format("/sentence/token/" + id), true);
 	}
 

--- a/src/main/resources/templates/fragments/search/results.html
+++ b/src/main/resources/templates/fragments/search/results.html
@@ -109,7 +109,7 @@
       <!-- Block view -->
       <table class="sentence-line-mode">
          <tr th:each="obj : ${searchResults}" class="occ-list-item" th:object="${obj}" th:with="hasGlyphs=*{hasGlyphs},isArtificiallyAligned=*{isArtificiallyAligned},position=*{getContextPosition}">
-              <td>(<a th:href="${(#mvc.url('SC#getSingleObjectDetailsPage').arg(0,obj.id)).build()}" th:text="${position}">1</a>)</td>
+              <td>(<a th:href="${(#mvc.url('SC#getSingleObjectDetailsPage').arg(0,obj.id)).build()}" th:text="${position}+1">1</a>)</td>
               
               <td>
                 <div class="mt-sm-1 py-sm-1">


### PR DESCRIPTION
Sentence-ID lookup gefixed
Textsatzeite Positionsangaben um 1 erhöht, damit "Erster" Satz nicht mehr mit Stellenangabe 0 sondern 1 angezeigt wird.